### PR TITLE
Improved : the header name can now be customized

### DIFF
--- a/src/StopwatchMiddleware.php
+++ b/src/StopwatchMiddleware.php
@@ -15,18 +15,37 @@ use Symfony\Component\Stopwatch\Stopwatch;
 class StopwatchMiddleware
 {
     /**
-     * @var Stopwatch
+     * @var Stopwatch The stopwatch service.
      */
     protected $stopwatch;
 
     /**
+     * @var string The name of the header where the request duration is stored.
+     */
+    protected $headerName = 'X-Duration';
+
+    /**
      * Creates a callable Middleware for timing guzzle requests.
      *
-     * @param Stopwatch $stopwatch
+     * @param Stopwatch $stopwatch The stopwatch service.
      */
     public function __construct(Stopwatch $stopwatch = null)
     {
         $this->stopwatch = $stopwatch;
+    }
+
+    /**
+     * Sets the name of the header where the request duration is stored.
+     *
+     * @param string $headerName The name of the header where the request duration is stored.
+     *
+     * @return StopwatchMiddleware
+     */
+    public function setHeaderName($headerName)
+    {
+        $this->headerName = $headerName;
+
+        return $this;
     }
 
     /**
@@ -53,7 +72,8 @@ class StopwatchMiddleware
 
             if (null !== $this->stopwatch) {
                 $event = $this->stopwatch->stop((string)$request->getUri());
-                return $response->withHeader('X-Duration', $event->getDuration());
+
+                return $response->withHeader($this->headerName, $event->getDuration());
             }
 
             return $response;

--- a/tests/StopwatchMiddlewareTest.php
+++ b/tests/StopwatchMiddlewareTest.php
@@ -48,7 +48,9 @@ class StopwatchMiddlewareTest extends \PHPUnit_Framework_TestCase
         $stopwatch->shouldReceive('stop')->once()->with('http://example.com')->andReturn($event);
 
         // Middleware
+        $headerName = 'X-Duration';
         $middleware = new StopwatchMiddleware($stopwatch);
+        $middleware->setHeaderName($headerName);
         $stack->push($middleware);
 
         $handler = $stack->resolve();
@@ -58,7 +60,7 @@ class StopwatchMiddlewareTest extends \PHPUnit_Framework_TestCase
         $promise = $handler($request, []);
         $response = $promise->wait();
 
-        $this->assertEquals($response->getHeaderLine('X-Duration'), $duration);
+        $this->assertEquals($response->getHeaderLine($headerName), $duration);
     }
 
     /**


### PR DESCRIPTION
Up until now, the name of the header was X-Duration.

This PR aims to add `setHeaderName` in order to specify the name of the header.

This PR does not break backward compatibility.