### PR TITLE
fix: don't stop stopwatch if not started

### DIFF
--- a/src/StopwatchMiddleware.php
+++ b/src/StopwatchMiddleware.php
@@ -70,7 +70,7 @@ class StopwatchMiddleware
     {
         return function (ResponseInterface $response) use ($request) {
 
-            if (null !== $this->stopwatch) {
+            if (null !== $this->stopwatch && $this->stopwatch->isStarted((string)$request->getUri())) {
                 $event = $this->stopwatch->stop((string)$request->getUri());
 
                 return $response->withHeader($this->headerName, $event->getDuration());


### PR DESCRIPTION
I've noticed a race condition affecting async Guzzle requests where there can be an attempt to stop a stopwatch that has not yet been started.