### PR TITLE
Update dependencies since PHP < 7.2 are EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: php
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
     - 7.2
     - 7.3
+    - 7.4
 
 install:
     - travis_retry composer self-update

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Brice Mancone
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -7,18 +7,18 @@
   "authors": [
     {
       "name":     "Brice Mancone",
-      "email":    "brice.mancone@gmail.com",
+      "email":    "brice@mancone.fr",
       "homepage": "https://github.com/bmancone"
     }
   ],
   "require": {
-    "php" : ">=5.5",
-    "symfony/stopwatch": "^2.3|^3|^4",
+    "php" : ">=7.2",
+    "symfony/stopwatch": "^3.4|^4.0|^5.0",
     "guzzlehttp/guzzle": "^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "~4.6",
-    "mockery/mockery": "~0.9"
+    "phpunit/phpunit" : "^8.0",
+    "mockery/mockery": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/StopwatchMiddleware.php
+++ b/src/StopwatchMiddleware.php
@@ -9,8 +9,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
  * Stopwatch Middleware for Guzzle.
- *
- * @author Brice Mancone <brice.mancone@gmail.com>
  */
 class StopwatchMiddleware
 {

--- a/tests/StopwatchMiddlewareTest.php
+++ b/tests/StopwatchMiddlewareTest.php
@@ -14,10 +14,9 @@ use \Mockery as m;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
-/**
- * @author Brice Mancone <brice.mancone@gmail.com>
- */
-class StopwatchMiddlewareTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class StopwatchMiddlewareTest extends TestCase
 {
     /**
      * @return array Durations.


### PR DESCRIPTION
Updated dependencies since PHP versions < 7.2 are EOL.

|Dependency|Version(s)|
|-----------------|-------------|
|Symfony|^3.4\|^4.0\|^5|
|Phpunit|^8.0|
|Mockery|^1.3| 